### PR TITLE
Adding a timeout function to the AppBladeWebClient

### DIFF
--- a/iOS/Framework/AppBlade/AppBlade.m
+++ b/iOS/Framework/AppBlade/AppBlade.m
@@ -1486,6 +1486,7 @@ static BOOL is_encrypted () {
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:sessionFilePath]) {
         NSArray* sessions = (NSArray*)[self readFile:sessionFilePath];
+        
         ABDebugLog_internal(@"%d Sessions Exist, posting them", [sessions count]);
         
         if(![self hasPendingSessions]){
@@ -1789,7 +1790,7 @@ static BOOL is_encrypted () {
     else {
         NSError* error = nil;
         if (![[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
-            ABErrorLog(@"AppBlade cannot remove file %@", [filePath lastPathComponent]);
+            ABErrorLog(@"AppBlade cannot remove file %@ : Error: %@", filePath, error);
         }
     }
     return returnObject;

--- a/iOS/Framework/AppBlade/AppBladeWebClient.m
+++ b/iOS/Framework/AppBlade/AppBladeWebClient.m
@@ -277,8 +277,9 @@ const int kNonceRandomStringLength = 74;
         return;
     }
     
-    
-    ABErrorLog(@"AppBlade failed with error: %@ for %@", error.localizedDescription, self.request.URL);
+    if(error){
+        ABErrorLog(@"AppBlade failed with error: %@ for %@", error.localizedDescription, self.request.URL);
+    }
     
     AppBladeWebClient *selfReference = self;
     id<AppBladeWebClientDelegate> delegateReference = self.delegate;
@@ -349,7 +350,9 @@ const int kNonceRandomStringLength = 74;
         }
         else
         {
-            ABErrorLog(@"Error parsing permisions json: %@", [error debugDescription]);
+            if(error){
+                ABErrorLog(@"Error parsing permisions json: %@", [error debugDescription]);
+            }
             AppBladeWebClient *selfReference = self;
             id<AppBladeWebClientDelegate> delegateReference = self.delegate;
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -402,7 +405,9 @@ const int kNonceRandomStringLength = 74;
         }
         else
         {
-            ABErrorLog(@"Error parsing update plist: %@", [error debugDescription]);
+            if(error){
+                ABErrorLog(@"Error parsing update plist: %@", [error debugDescription]);
+            }
             AppBladeWebClient *selfReference = self;
             id<AppBladeWebClientDelegate> delegateReference = self.delegate;
             dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
@andrewtremblay @joe-goullaud Can you guys look over this.

I was getting a crash when a web request from Appblade would timeout.  It looks like we never implemented the actual timeout method, just the Perform Selector for it.  

Tested it by reducing the timeouts down to 5 second and then using the Network Link Conditioner to force a timeout.
