### PR TITLE
Null check of device secret

### DIFF
--- a/iOS/Framework/AppBlade/AppBlade.m
+++ b/iOS/Framework/AppBlade/AppBlade.m
@@ -711,7 +711,7 @@ static BOOL is_encrypted () {
             // users from unlocking an app by simply changing their clock.
             ABDebugLog_internal(@"Permissions callback : %@", client.sentDeviceSecret);
 
-            if ([self withinStoredTTL] || client.sentDeviceSecret == nil) {
+            if ([self withinStoredTTL] || (client.sentDeviceSecret == nil)) {
                 if(canSignalDelegate) {
                     [self.delegate appBlade:self applicationApproved:YES error:nil];
                 }


### PR DESCRIPTION
It's being reported that the first time an app is opened with checkAuthentication the lack of a device secret at first call causes a killswitch to fire. 
Originally this was supposed to be handled by checking if the token was current, but that wasn't working. Now we're checking for the null. 
