### PR TITLE
Add -mno-thumb to OTHER_CFLAGS

### DIFF
--- a/iOS/Framework/AppBlade.xcodeproj/project.pbxproj
+++ b/iOS/Framework/AppBlade.xcodeproj/project.pbxproj
@@ -859,6 +859,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = "-mno-thumb";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				VALID_ARCHS = "armv7 armv7s i386";
@@ -909,6 +910,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = "-mno-thumb";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				VALID_ARCHS = "armv7 armv7s i386";
@@ -957,6 +959,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = "-mno-thumb";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				VALID_ARCHS = "armv7 armv7s i386";
@@ -1119,6 +1122,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = "-mno-thumb";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				VALID_ARCHS = "armv7 armv7s i386";

--- a/iOS/Framework/AppBlade.xcodeproj/project.pbxproj
+++ b/iOS/Framework/AppBlade.xcodeproj/project.pbxproj
@@ -887,7 +887,6 @@
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/lib/system\"",
 				);
-				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -939,7 +938,10 @@
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/lib/system\"",
 				);
-				OTHER_CFLAGS = "-DSTAGING=1";
+				OTHER_CFLAGS = (
+					"-DSTAGING=1",
+					"-mno-thumb",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -987,7 +989,10 @@
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/lib/system\"",
 				);
-				OTHER_CFLAGS = "-DSTAGING=1";
+				OTHER_CFLAGS = (
+					"-DSTAGING=1",
+					"-mno-thumb",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
The framework project sets GCC_THUMB_SUPPORT = NO, but we are getting link errors in Paper that indicate that THUMB instructions are being used:

```
ld: b/bl/blx thumb2 branch out of range (17017136 max is +/-16MB): from _protobuf_c_out_of_memory_default (0x02418BCC) to _abort@0x00000000 (0x03453524) in '_protobuf_c_out_of_memory_default' from /Users/jenkins/jenkins/workspace/Paper_develop/iOS/ThirdParty/AppBlade/iOS/Framework/build/Release_Production-iphoneos/libAppBlade.a(protobuf-c.o) for architecture armv7
```

There is anecdotal evidence that GCC_THUMB_SUPPORT doesn't really do anything:
https://twitter.com/luzluz/status/184563684423630848

This change adds the `-mno-thumb` flag to the compiler options.

PTAL @jamesdaniels @mtjhax 
/cc @petersibley @mliberman