### PR TITLE
CocoaPods compatibilty with PLCrashreporter

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -7,7 +7,7 @@
 
 The easiest and quickest way to get your project using the AppBlade iOS SDK is to use CocoaPods. Add the following to your `Podfile`:
 
-    pod 'appblade'
+    pod 'AppBlade'
     
 Then run `pod install` on your command line. Mind that you'll still need to fetch the `AppBladeKeys.plist`  personalized for your project and add it to your `ResourceRules` [Not a CocoaPods user? Navigate here to learn about other installation methods.](https://github.com/AppBlade/AppBladeSDK/wiki/Embedding-our-SDK)
 

--- a/iOS/Framework/AppBlade/AppBlade.m
+++ b/iOS/Framework/AppBlade/AppBlade.m
@@ -10,12 +10,12 @@
 #import "AppBladeLogging.h"
 #import "AppBladeSimpleKeychain.h"
 
-#import "PLCrashReporter.h"
+#import "CrashReporter/PLCrashReporter.h"
 #include "PLCrashReporter+AppBlade.h"
 
-#import "PLCrashReport.h"
+#import "CrashReporter/PLCrashReport.h"
 #import "AppBladeWebClient.h"
-#import "PLCrashReportTextFormatter.h"
+#import "CrashReporter/PLCrashReportTextFormatter.h"
 #import "FeedbackDialogue.h"
 #import "asl.h"
 #import <QuartzCore/QuartzCore.h>

--- a/iOS/Framework/AppBlade/PLCrashReporter+AppBlade.h
+++ b/iOS/Framework/AppBlade/PLCrashReporter+AppBlade.h
@@ -5,7 +5,7 @@
 //  Created by AndrewTremblay on 2/6/14.
 //  Copyright (c) 2014 Raizlabs Corporation. All rights reserved.
 //
-#import "PLCrashReporter.h"
+#import "CrashReporter/PLCrashReporter.h"
 
 // these once-public, now-private methods are required by AppBlade for backwards compatibility
 @interface PLCrashReporter ()


### PR DESCRIPTION
Updated the directory where the PLCrashreporter is, so is compatible with the cocoapods version of the library